### PR TITLE
FEAT: Allows the client to just fire a message

### DIFF
--- a/src/IframeMessageProxy.ts
+++ b/src/IframeMessageProxy.ts
@@ -178,9 +178,9 @@ export class IframeMessageProxy {
    */
   public sendMessage(payload: IMessagePayload): Promise<any> {
     const message = this.formatPayload(payload)
-    const deferred = createDeferred()
+    const deferred = createDeferred() 
 
-    if (!message.message.fireAndForget) {
+    if (!payload.fireAndForget) {
       this.createPromiseCache(message.trackingProperties.id, deferred)
     }
 

--- a/src/IframeMessageProxy.ts
+++ b/src/IframeMessageProxy.ts
@@ -4,7 +4,8 @@ import { randomStr } from './utils/string'
 export interface IMessagePayload {
   action: string
   content?: any
-  caller?: string
+  caller?: string,
+  fireAndForget?: boolean
 }
 
 export interface IDeferredCache {
@@ -175,11 +176,11 @@ export class IframeMessageProxy {
    * @param payload
    * @param element
    */
-  public sendMessage(payload: IMessagePayload, trackPromise: boolean = true): Promise<any> {
+  public sendMessage(payload: IMessagePayload): Promise<any> {
     const message = this.formatPayload(payload)
     const deferred = createDeferred()
 
-    if (trackPromise) {
+    if (!message.message.fireAndForget) {
       this.createPromiseCache(message.trackingProperties.id, deferred)
     }
 

--- a/src/IframeMessageProxy.ts
+++ b/src/IframeMessageProxy.ts
@@ -175,11 +175,14 @@ export class IframeMessageProxy {
    * @param payload
    * @param element
    */
-  public sendMessage(payload: IMessagePayload): Promise<any> {
+  public sendMessage(payload: IMessagePayload, trackPromise: boolean = true): Promise<any> {
     const message = this.formatPayload(payload)
     const deferred = createDeferred()
 
-    this.createPromiseCache(message.trackingProperties.id, deferred)
+    if (trackPromise) {
+      this.createPromiseCache(message.trackingProperties.id, deferred)
+    }
+
     this.targetWindow.postMessage(message, '*')
 
     return deferred.promise


### PR DESCRIPTION
Added a parameter on the sendMessage method that will inform the system whether or not it should maintain a promise on cache. It will allow the system to just fire messages without expecting a result as a return.